### PR TITLE
appy stylesheet to notebook output compatible with jupyterlab_bokeh

### DIFF
--- a/backtrader_plotting/bokeh/templates/basic.css.j2
+++ b/backtrader_plotting/bokeh/templates/basic.css.j2
@@ -1,0 +1,57 @@
+<style>
+    body {
+        background-color: {{body_background_color}};
+        color: {{text_color}};
+    }
+
+    #headline {
+        font-size: 200%;
+        font-family: "Segoe UI", "Arial Black", Gadget, sans-serif;
+        color: {{headline_color}};
+    }
+
+    .bk-root {
+        font-family: "Segoe UI", "Arial Black", Gadget, sans-serif;
+    }
+    .bk-toolbar {position: fixed;}
+
+    .slick-header-column {
+        background-color: {{datatable_header_color}} !important;
+        background-image: none !important;
+        font-size: 130%;
+    }
+
+    .slick-row.even {
+        background-color: {{datatable_row_color_even}} !important;
+    }
+
+    .slick-row.odd {
+        background-color: {{datatable_row_color_odd}} !important;
+    }
+
+    .bk-root .bk-bs-nav-tabs>li.bk-bs-active>span {
+        background-color: {{tab_active_background_color}} !important;
+        color: {{tab_active_color}} !important;
+        border-color: {{tab_active_background_color}} !important;
+    }
+
+    .bk-root .bk-bs-nav>li>span:hover {
+        background-color: {{tab_active_background_color}} !important;
+        border-color: {{tab_active_background_color}} !important;
+        color: {{tab_active_color}} !important;
+    }
+
+    .bk-tooltip {
+        border-radius: 3px;
+        background-color: {{tooltip_background_color}} !important;
+        border-color: {{tooltip_background_color}} !important;
+    }
+
+    .bk-tooltip-row-label {
+        color: {{tooltip_text_color_label}} !important;
+    }
+
+    .bk-tooltip-row-value {
+        color: {{tooltip_text_color_value}} !important;
+    }
+</style>

--- a/backtrader_plotting/bokeh/templates/basic.html.j2
+++ b/backtrader_plotting/bokeh/templates/basic.html.j2
@@ -24,63 +24,7 @@ that accepts these same parameters.
         <title>{{ title|e if title else "Bokeh Plot" }}</title>
         {{ bokeh_css }}
         {{ bokeh_js }}
-        <style>
-            body {
-                background-color: {{body_background_color}};
-                color: {{text_color}};
-            }
-
-            #headline {
-                font-size: 200%;
-                font-family: "Segoe UI", "Arial Black", Gadget, sans-serif;
-                color: {{headline_color}};
-            }
-
-            .bk-root {
-                font-family: "Segoe UI", "Arial Black", Gadget, sans-serif;
-            }
-            .bk-toolbar {position: fixed;}
-
-            .slick-header-column {
-                background-color: {{datatable_header_color}} !important;
-                background-image: none !important;
-                font-size: 130%;
-            }
-
-            .slick-row.even {
-                background-color: {{datatable_row_color_even}} !important;
-            }
-
-            .slick-row.odd {
-                background-color: {{datatable_row_color_odd}} !important;
-            }
-
-            .bk-root .bk-bs-nav-tabs>li.bk-bs-active>span {
-                background-color: {{tab_active_background_color}} !important;
-                color: {{tab_active_color}} !important;
-                border-color: {{tab_active_background_color}} !important;
-            }
-
-            .bk-root .bk-bs-nav>li>span:hover {
-                background-color: {{tab_active_background_color}} !important;
-                border-color: {{tab_active_background_color}} !important;
-                color: {{tab_active_color}} !important;
-            }
-
-            .bk-tooltip {
-                border-radius: 3px;
-                background-color: {{tooltip_background_color}} !important;
-                border-color: {{tooltip_background_color}} !important;
-            }
-
-            .bk-tooltip-row-label {
-                color: {{tooltip_text_color_label}} !important;
-            }
-
-            .bk-tooltip-row-value {
-                color: {{tooltip_text_color_value}} !important;
-            }
-        </style>
+        {{ stylesheet }}
     </head>
     <body>
         {%if show_headline %}


### PR DESCRIPTION
Last PR #4 did not apply template with stylesheet to notebook output and this PR attempts to fix that.  The CSS portion of original template needs to be separated out:  script execution from HTML() output will be blocked by JupyterLab (even with jupyterlab_bokeh plugin) when not fed through a show() command to attach proper MIME type.