### PR TITLE
Fixes type mismatch on hovers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+backtrader_plotting.egg-info

--- a/backtrader_plotting/bokeh/figure.py
+++ b/backtrader_plotting/bokeh/figure.py
@@ -81,7 +81,10 @@ class Figure(object):
         if self._hover_line_set:
             return
 
-        self._hover.renderers.append(ren)
+        if isinstance(self._hover.renderers, list) != True:
+            self._hover.renderers = [ren]
+        else:
+            self._hover.renderers.append(ren)
 
     def _nextcolor(self, key: object=None) -> None:
         self._coloridx[key] += 1


### PR DESCRIPTION
I've added the plotting integration by submoduling into my project, activating the right virtualenv and running `pip install -e .` as well as installing bokeh/pandas. This is not as per the readme but how I managed to get things working (setuptools was crashing and burning for me).

I was getting this error:

```
Traceback (most recent call last):
  File "MACD_RSI_EMA.py", line 123, in <module>
    runstrat(False, OrderDealer, 0)
  File "MACD_RSI_EMA.py", line 119, in runstrat
    cerebro.plot(b)
  File "/Users/jhogendorn/.virtualenvs/Bot/lib/python3.6/site-packages/backtrader/cerebro.py", line 991, in plot
    start=start, end=end, use=use)
  File "/Users/jhogendorn/Code/project/backtrader_plotting/bokeh/bokeh.py", line 401, in plot
    self._blueprint_strategy(obj, start, end, **kwargs)
  File "/Users/jhogendorn/Code/project/backtrader_plotting/bokeh/bokeh.py", line 244, in _blueprint_strategy
    bf.plot(master, strat_clk, None)
  File "/Users/jhogendorn/Code/project/backtrader_plotting/bokeh/figure.py", line 160, in plot
    self.plot_observer(obj, master)
  File "/Users/jhogendorn/Code/project/backtrader_plotting/bokeh/figure.py", line 185, in plot_observer
    self.plot_indicator(obj, master)
  File "/Users/jhogendorn/Code/project/backtrader_plotting/bokeh/figure.py", line 293, in plot_indicator
    self._add_hover_renderer(renderer)
  File "/Users/jhogendorn/Code/project/backtrader_plotting/bokeh/figure.py", line 84, in _add_hover_renderer
    self._hover.renderers.append(ren)
AttributeError: 'str' object has no attribute 'append'
```

It seems that in my case it was expecting a list but was not yet initialised as seen in the alternative function. I just threw in an ifelse here to solve things and it seems ok. No idea if this is the correct fix though.

Feedback very welcome, I am not a python person by trade, just by hobby.