### PR TITLE
add tuple type handler to paramval2str

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## When creating an issue please follow these guidelines:
+
+* Describe what you did, what you expected to happen and what happened instead
+* Provide a minimal runnable source code example that shows the bug
+* Make sure you are using the latest version of the library
+* Include the version of the library you are using (or the exact commit hash)
+* Include version of your Python interpreter and of involved other libraries
+
+Thanks alot, reporting bugs is highly appreciated!

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Needs Python >= 3.6.
 ## Demos
 https://verybadsoldier.github.io/backtrader_plotting/
 
+## Installation
+`pip install backtrader_plotting`
+
 ## Quickstart
 
 ```python

--- a/backtrader_plotting/utils.py
+++ b/backtrader_plotting/utils.py
@@ -23,6 +23,8 @@ def paramval2str(name, value):
         return str(value)
     elif isinstance(value, list):
         return ','.join(value)
+    elif isinstance(value, tuple):
+        return ','.join(value)
     elif isinstance(value, type):
         return value.__name__
     else:


### PR DESCRIPTION
Transactions analyzer will transfer a tuple to paramval2str and cause :
    TypeError: unsupported format string passed to tuple.__format__
so need to add tuple type handler to paramval2str