### PR TITLE
add tuple handler to paramval2str in utils.py

### DIFF
--- a/backtrader_plotting/utils.py
+++ b/backtrader_plotting/utils.py
@@ -19,7 +19,7 @@ def paramval2str(name, value):
         return bt.TimeFrame.getname(value, 1)
     elif isinstance(value, float):
         return f"{value:.2f}"
-    elif isinstance(value, list):
+    elif isinstance(value, (list,tuple)):
         return ','.join(value)
     elif isinstance(value, type):
         return value.__name__


### PR DESCRIPTION
Transactions analyzer will transfer a tuple to paramval2str and cause
 TypeError: unsupported format string passed to tuple.__format__

so need to add tuple type handler to paramval2str