### PR TITLE
Fixed running with multiple different strategies...

### DIFF
--- a/backtrader_plotting/bokeh/bokeh_webapp.py
+++ b/backtrader_plotting/bokeh/bokeh_webapp.py
@@ -21,7 +21,7 @@ class BokehWebapp:
         self._port = port
         self._on_session_destroyed = on_session_destroyed
 
-    def start(self, ioloop=None):
+    def start(self, ioloop=None, iplot=True):
         """Serves a backtrader result as a Bokeh application running on a web server"""
         def make_document(doc: Document):
             if self._on_session_destroyed is not None:
@@ -39,7 +39,7 @@ class BokehWebapp:
             model = self._model_factory_fnc(doc)
             doc.add_root(model)
 
-        self._run_server(make_document, ioloop=ioloop, port=self._port)
+        self._run_server(make_document, iplot=iplot, ioloop=ioloop, port=self._port)
 
     @staticmethod
     def _run_server(fnc_make_document, iplot=True, notebook_url="localhost:8889", port=80, ioloop=None):

--- a/backtrader_plotting/bokeh/optbrowser.py
+++ b/backtrader_plotting/bokeh/optbrowser.py
@@ -21,9 +21,9 @@ class OptBrowser:
         self._sortasc = sortasc
         self._optresults = optresults
 
-    def start(self, ioloop=None):
+    def start(self, ioloop=None, iplot=True):
         webapp = BokehWebapp("Backtrader Optimization Result", "basic.html.j2", self._bokeh.params.scheme, self.build_optresult_model)
-        webapp.start(ioloop)
+        webapp.start(ioloop, iplot=iplot)
 
     def _build_optresult_selector(self, optresults) -> Tuple[DataTable, ColumnDataSource]:
         # 1. build a dict with all params and all user columns
@@ -32,7 +32,11 @@ class OptBrowser:
             for param_name, _ in optres[0].params._getitems():
                 param_val = optres[0].params._get(param_name)
                 data_dict[param_name].append(param_val)
-
+            if not optres[0].params._getitems():
+                for key, value in data_dict.items():
+                    v = value[0]
+                    val = type(v)() # create empty val of the same type
+                    data_dict[key].append(val)
             for usercol_label, usercol_fnc in self._usercolumns.items():
                 data_dict[usercol_label].append(usercol_fnc(optres))
 

--- a/backtrader_plotting/html/metadata.py
+++ b/backtrader_plotting/html/metadata.py
@@ -65,8 +65,9 @@ def _get_strategy(strategy: bt.Strategy, include_src=True) -> str:
         md += _get_parameter_table(i.params)
 
     if include_src:
-        md += 'Source Code:\n'
-        md += f'\n```\n{inspect.getsource(strategy.__class__)}\n```\n\n'
+        pass
+        #md += 'Source Code:\n'
+        #md += f'\n```\n{inspect.getsource(strategy.__class__)}\n```\n\n'
 
     return md
 


### PR DESCRIPTION
Fixed running with multiple different strategies using StFetcher (tested custom strategy and BuyAndHold backtrader test strategy); fixed plotting in Pycharm (iplot was set by default)

Example code with running multiple strategies:
strategy_params is a dict of custom parameters:
```
            strategy_params = dict(fast=range(20, 30, 4),
                        slow=range(20, 30, 4),)
            class StFetcher(object):
                _STRATS = [] #list of dicts(key=strategy,value=kwargs)

                def __new__(cls, *args, **kwargs):
                    idx = kwargs.pop('idx')
                    (key, value), = cls._STRATS[idx].items()
                    obj = key(*args, **{**kwargs, **value})
                    return obj
            StFetcher._STRATS = [{SMACrossLongShort: strategy_params},
                                 {BuyAndHold_Buy: strategy_params}] #actually it should be an empty dict

            cerebro.optstrategy(StFetcher, idx=[0, 1])
            bo = Bokeh()
            browser = OptBrowser(bo, optimized_runs)
            browser.start(iplot=False)
```
<img width="1619" alt="SMAStrategy" src="https://user-images.githubusercontent.com/3992716/107270035-1a3d8000-6a53-11eb-974a-dede5c8395d9.png">
<img width="1622" alt="BuyAndHold" src="https://user-images.githubusercontent.com/3992716/107270042-1c9fda00-6a53-11eb-8717-15b17f82da26.png">
