### PR TITLE
Fixed paramval2str type error for non-str lists

### DIFF
--- a/backtrader_plotting/utils.py
+++ b/backtrader_plotting/utils.py
@@ -24,7 +24,7 @@ def paramval2str(name, value):
     elif isinstance(value, float):
         return f"{value:.2f}"
     elif isinstance(value, (list,tuple)):
-        return ','.join(value)
+        return ','.join(map(lambda x: paramval2str(name, x), value))
     elif isinstance(value, type):
         return value.__name__
     else:


### PR DESCRIPTION
Hi, if you have parameter with list of something other than list (e.g. list of dicts), you'll get a error `TypeError: sequence item 0: expected str instance, <YOUR_NON_STR_TYPE_HERE> found`.

With this fix you'll convert everything to string recursively, thus preserving better text output.

Slightly better than https://github.com/verybadsoldier/backtrader_plotting/pull/88