### PR TITLE
Fixed paramval2str type error for non-str lists (With version change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2022.04.15
+### Fixes
+- Fixed paramval2str type error for non-str lists
+
+
 ## [2.0.0] - 2021.06.14
 ### Added
 - Live trading support (needs custom `backtrader`, see `README.md` for details)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2022.04.15
+### Fixes
+- Fixed paramval2str type error for non-str lists
+
 ## [2.0.0] - 2021.06.14
 ### Added
 - Live trading support (needs custom `backtrader`, see `README.md` for details)

--- a/backtrader_plotting/utils.py
+++ b/backtrader_plotting/utils.py
@@ -24,7 +24,7 @@ def paramval2str(name, value):
     elif isinstance(value, float):
         return f"{value:.2f}"
     elif isinstance(value, (list,tuple)):
-        return ','.join(value)
+        return ','.join(map(lambda x: paramval2str(name, x), value))
     elif isinstance(value, type):
         return value.__name__
     else:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name='backtrader_plotting',
 
-    version='2.0.0',
+    version='2.0.1',
 
     description='Plotting package for Backtrader (Bokeh)',
 


### PR DESCRIPTION
Same as https://github.com/verybadsoldier/backtrader_plotting/pull/91 , but with version change and changelog
___
Hi, if you have parameter with list of something other than list (e.g. list of dicts), you'll get a error `TypeError: sequence item 0: expected str instance, <YOUR_NON_STR_TYPE_HERE> found`.

With this fix you'll convert everything to string recursively, thus preserving better text output.

Slightly better than https://github.com/verybadsoldier/backtrader_plotting/pull/88